### PR TITLE
fix: unshallow git clone on travis during deploy

### DIFF
--- a/playbooks/roles/app/templates/deploy-app.sh.j2
+++ b/playbooks/roles/app/templates/deploy-app.sh.j2
@@ -5,6 +5,8 @@ set -euo pipefail
 if [ $TRAVIS_BRANCH == '{{app.git_branch}}' ]; then
     echo '=== Starting deployment of {{app.app_id}}...'
 
+    git fetch --unshallow
+
     git remote add deploy 'deploy@plugboard.xyz:~/{{app.app_id}}'
     ssh-agent bash -c 'ssh-add "$DEPLOY_KEY" && git push --force deploy {{app.git_branch}}:master'
 

--- a/scripts/deploy-app-plugboard_beta.sh
+++ b/scripts/deploy-app-plugboard_beta.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 if [ $TRAVIS_BRANCH == 'develop' ]; then
     echo '=== Starting deployment of plugboard_beta...'
 
+    git fetch --unshallow
+
     git remote add deploy 'deploy@plugboard.xyz:~/plugboard_beta'
     ssh-agent bash -c 'ssh-add "$DEPLOY_KEY" && git push --force deploy develop:master'
 

--- a/scripts/deploy-app-plugboard_prod.sh
+++ b/scripts/deploy-app-plugboard_prod.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 if [ $TRAVIS_BRANCH == 'master' ]; then
     echo '=== Starting deployment of plugboard_prod...'
 
+    git fetch --unshallow
+
     git remote add deploy 'deploy@plugboard.xyz:~/plugboard_prod'
     ssh-agent bash -c 'ssh-add "$DEPLOY_KEY" && git push --force deploy master:master'
 


### PR DESCRIPTION
Travis CI only clone with a depth of 50 commits. However it's not allow to push to a remote from a shallow clone. The fix convert the clone to a full clone before each deployment.